### PR TITLE
Externally owned kernel is no longer disposed

### DIFF
--- a/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
+++ b/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-rc0001\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -61,6 +65,7 @@
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="When_declaring_a_public_property.cs" />
     <Compile Include="When_setting_properties_explicitly_via_the_container.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.Ninject.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Ninject.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Ninject.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using global::Ninject;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_shutdown_properly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.Kernel.IsDisposed);
+            Assert.DoesNotThrow(() => context.Kernel.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public IKernel Kernel { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, desc) =>
+                {
+                    var kernel = new StandardKernel();
+
+                    config.UseContainer<NinjectBuilder>(c => c.ExistingKernel(kernel));
+
+                    var context = (Context) desc.ScenarioContext;
+                    context.Kernel = kernel;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Ninject.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Ninject.AcceptanceTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Ninject" version="3.2.2.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />

--- a/src/NServiceBus.Ninject.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Ninject.Tests/DisposalTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Ninject.Tests
+{
+    using global::Ninject;
+    using NUnit.Framework;
+    using ObjectBuilder.Ninject;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var kernel = new StandardKernel();
+
+            var container = new NinjectObjectBuilder(kernel, true);
+            container.Dispose();
+
+            Assert.True(kernel.IsDisposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var kernel = new StandardKernel();
+
+            var container = new NinjectObjectBuilder(kernel, false);
+            container.Dispose();
+
+            Assert.False(kernel.IsDisposed);
+        }
+    }
+}

--- a/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
+++ b/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_querying_for_registered_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Ninject.Tests/SetUpFixture.cs
+++ b/src/NServiceBus.Ninject.Tests/SetUpFixture.cs
@@ -16,10 +16,10 @@ public class SetUpFixture
 
     static IContainer ConstructNinjectObjectBuilder()
     {
-        var ninjectSettings = new NinjectSettings {LoadExtensions = false};
+        var ninjectSettings = new NinjectSettings { LoadExtensions = false };
         var contextPreservationModule = new ContextPreservationModule();
         var namedScopeModule = new NamedScopeModule();
         var standardKernel = new StandardKernel(ninjectSettings,contextPreservationModule, namedScopeModule);
-        return new NinjectObjectBuilder(standardKernel);
+        return new NinjectObjectBuilder(standardKernel, true);
     }
 }

--- a/src/NServiceBus.Ninject/NinjectBuilder.cs
+++ b/src/NServiceBus.Ninject/NinjectBuilder.cs
@@ -2,6 +2,7 @@
 {
     using Container;
     using Ninject;
+    using ObjectBuilder.Common;
     using ObjectBuilder.Ninject;
     using Settings;
 
@@ -11,21 +12,30 @@
     public class NinjectBuilder : ContainerDefinition
     {
         /// <summary>
-        ///     Implementers need to new up a new container.
+        /// Implementers need to new up a new container.
         /// </summary>
         /// <param name="settings">The settings to check if an existing container exists.</param>
         /// <returns>The new container wrapper.</returns>
-        public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
+        public override IContainer CreateContainer(ReadOnlySettings settings)
         {
-            IKernel existingKernel;
+            KernelHolder kernelHolder;
 
-            if (settings.TryGet("ExistingKernel", out existingKernel))
+            if (settings.TryGet(out kernelHolder))
             {
-                return new NinjectObjectBuilder(existingKernel);
-
+                return new NinjectObjectBuilder(kernelHolder.ExistingKernel);
             }
 
             return new NinjectObjectBuilder();
+        }
+
+        internal class KernelHolder
+        {
+            public KernelHolder(IKernel kernel)
+            {
+                ExistingKernel = kernel;
+            }
+
+            public IKernel ExistingKernel { get; }
         }
     }
 }

--- a/src/NServiceBus.Ninject/NinjectExtensions.cs
+++ b/src/NServiceBus.Ninject/NinjectExtensions.cs
@@ -15,7 +15,7 @@
         /// <param name="kernel">The existing container instance.</param>
         public static void ExistingKernel(this ContainerCustomizations customizations, IKernel kernel)
         {
-            customizations.Settings.Set("ExistingKernel", kernel);
+            customizations.Settings.Set<NinjectBuilder.KernelHolder>(new NinjectBuilder.KernelHolder(kernel));
         }
     }
 }

--- a/src/NServiceBus.Ninject/NinjectObjectBuilder.cs
+++ b/src/NServiceBus.Ninject/NinjectObjectBuilder.cs
@@ -16,13 +16,19 @@
     class NinjectObjectBuilder : IContainer
     {
         public NinjectObjectBuilder()
-            : this(new StandardKernel())
+            : this(new StandardKernel(), true)
         {
         }
 
         public NinjectObjectBuilder(IKernel kernel)
+            : this(kernel, false)
+        {
+        }
+
+        public NinjectObjectBuilder(IKernel kernel, bool owned)
         {
             this.kernel = kernel;
+            this.owned = owned;
 
             RegisterNecessaryBindings();
 
@@ -148,12 +154,19 @@
 
         void DisposeManaged()
         {
-            if (kernel != null)
+            if (!owned)
             {
-                if (!kernel.IsDisposed)
-                {
-                    kernel.Dispose();
-                }
+                return;
+            }
+
+            if (kernel == null)
+            {
+                return;
+            }
+
+            if (!kernel.IsDisposed)
+            {
+                kernel.Dispose();
             }
         }
 
@@ -286,5 +299,6 @@
 
         IKernel kernel;
         IObjectBuilderPropertyHeuristic propertyHeuristic;
+        bool owned;
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the kernel instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.