### PR TITLE
Netstandard support

### DIFF
--- a/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
+++ b/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
-    <PackageReference Include="Ninject" Version="3.*" />
+    <PackageReference Include="Ninject" Version="3.3.3" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
+++ b/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="APIApprovals.Approve.received.txt" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Ninject\NServiceBus.Ninject.csproj" />
@@ -14,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
-    <PackageReference Include="Ninject" Version="3.2.2" />
+    <PackageReference Include="Ninject" Version="3.3.3" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
+++ b/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>NServiceBus.ObjectBuilder.Ninject</AssemblyName>
     <RootNamespace>NServiceBus.ObjectBuilder.Ninject</RootNamespace>
     <SignAssembly>true</SignAssembly>
@@ -14,10 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ninject" Version="3.2.2" />
-    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.2.0" />
-    <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.2.0,4.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
+    <PackageReference Include="Ninject" Version="[3.3.3,4.0.0)" />
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.3.0,4.0.0)" />
+    <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.3.0,4.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-*,8.0.0)" />
+    <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="all" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />


### PR DESCRIPTION
The lastest Ninject pre-release packages support Netstandard.

Currently they are not marked `CLSCompliant`, so this will not be ready to merge until they have added that back in and released non-prerelease versions. I submitted [a PR to Ninject](https://github.com/ninject/Ninject/pull/257) to do so.