### PR TITLE
Avoid bugs in Ninject.Extensions.ContextPreservation 3.3.0

### DIFF
--- a/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
+++ b/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
@@ -15,9 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
-    <PackageReference Include="Ninject" Version="3.*" />
-    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.*" />
-    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.*" />
+    <PackageReference Include="Ninject" Version="3.2.2" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
+++ b/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
@@ -16,8 +16,8 @@
     <PackageId>NServiceBus.Ninject</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ninject" Version="[3.2.2,4.0.0)" />
-    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.2.0,4.0.0)" />
+    <PackageReference Include="Ninject" Version="3.2.2" />
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.2.0" />
     <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.2.0,4.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-*,8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="all" />


### PR DESCRIPTION
Remove wildcards as newer versions cause tests to fail.