### PR TITLE
Update to NServiceBus beta10

### DIFF
--- a/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
+++ b/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
@@ -14,11 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
     <PackageReference Include="Ninject" Version="[3.3.3,4.0.0)" />
     <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.3.0,4.0.0)" />
     <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.3.0,4.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*,8.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="all" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />


### PR DESCRIPTION
beta10 contains a breaking change around the `AddStartupDiagnosticsSection` extension method, see https://github.com/Particular/NServiceBus/pull/5039/files and therefore needs to be recompiled against beta10.