### PR TITLE
Change References

### DIFF
--- a/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
+++ b/src/NServiceBus.Ninject.AcceptanceTests/NServiceBus.Ninject.AcceptanceTests.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
-    <PackageReference Include="Ninject" Version="3.3.3" />
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.3.1" />
+    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
+++ b/src/NServiceBus.Ninject.Tests/NServiceBus.Ninject.Tests.csproj
@@ -18,7 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
-    <PackageReference Include="Ninject" Version="3.3.3" />
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="3.3.1" />
+    <PackageReference Include="Ninject.Extensions.NamedScope" Version="3.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
+++ b/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
     <PackageReference Include="Ninject" Version="[3.3.3,4.0.0)" />
-    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.3.0,4.0.0)" />
+    <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.3.1,4.0.0)" />
     <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.3.0,4.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="all" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />

--- a/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
+++ b/src/NServiceBus.Ninject/NServiceBus.Ninject.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
-    <PackageReference Include="Ninject" Version="[3.3.3,4.0.0)" />
     <PackageReference Include="Ninject.Extensions.ContextPreservation" Version="[3.3.1,4.0.0)" />
     <PackageReference Include="Ninject.Extensions.NamedScope" Version="[3.3.0,4.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="all" />


### PR DESCRIPTION
So this change might be a bit controversial, but I wanted to suggest it and see what you think.

Since both of the extensions list a version of Ninject as a dependency, this lets the transitive dependencies resolve the version of the main package to reference.

Even if you don't want to do this, the first commit is a good idea, because it appears that the dependencies of Ninject.Extensions.ContextPreservation 3.3.0 had too many top-level items, and 3.3.1 fixes that.